### PR TITLE
Properly cross-builds 2.11/2.12 and releases to Sonatype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: scala
-scala:
-  - 2.12.3
-  - 2.11.11
 jdk:
   - oraclejdk8
 sudo: required
@@ -15,4 +12,4 @@ before_cache:
   # Delete all ivydata files since ivy touches them on each build
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
 script:
-  - sbt test
+  - sbt +test

--- a/build.sbt
+++ b/build.sbt
@@ -1,44 +1,72 @@
+import ReleaseTransformations._
+
 val Versions = new {
-  val akka24    = "2.4.12" // First version cross-compiled to 2.12
-  val akka25    = "2.5.0"
-  val lagom13   = "1.3.0"
-  val lagom14   = "1.4.0-M2"
-  val play25    = "2.5.0"
-  val play26    = "2.6.0"
-  val scala211  = "2.11.11"
-  val scala212  = "2.12.3"
-  val scalaTest = "3.0.1"
+  val akka24            = "2.4.12" // First version cross-compiled to 2.12
+  val akka25            = "2.5.0"
+  val lagom13           = "1.3.0"
+  val lagom14           = "1.4.0-M2"
+  val play25            = "2.5.0"
+  val play26            = "2.6.0"
+  val scala211          = "2.11.11"
+  val scala212          = "2.12.3"
+  val scalaTest         = "3.0.1"
+  val serviceLocatorDns = "2.2.2"
 }
 
 lazy val sharedSettings = Vector(
+  resolvers += Resolver.bintrayRepo("hajile", "maven"),
   organization := "com.lightbend.rp",
   organizationName := "Lightbend, Inc.",
   startYear := Some(2017),
   licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
-  scalaVersion := Versions.scala212,
-  crossScalaVersions := Vector(scalaVersion.value, Versions.scala211),
-  scalacOptions ++= Vector("-deprecation")
-)
-
-lazy val scala211Settings = Vector(
   scalaVersion := Versions.scala211,
-  crossScalaVersions := Vector(Versions.scala211)
+  scalacOptions ++= Vector("-deprecation"),
+  homepage := Some(url("https://www.lightbend.com/")),
+  developers := List(
+    Developer("lightbend", "Lightbend Contributors", "", url("https://github.com/typesafehub/reactive-lib"))
+  ),
+  sonatypeProfileName := "com.lightbend.rp",
+  scmInfo := Some(ScmInfo(url("https://github.com/typesafehub/reactive-lib"), "git@github.com:typesafehub/reactive-lib.git")),
+  scalaVersion := Versions.scala211,
+  publishTo := Some(
+    if (isSnapshot.value)
+      Opts.resolver.sonatypeSnapshots
+    else
+      Opts.resolver.sonatypeStaging
+  ),
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+  releaseCrossBuild := false,
+  releaseProcess := Seq[ReleaseStep](
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    releaseStepCommandAndRemaining("+test"),
+    setReleaseVersion,
+    commitReleaseVersion,
+    tagRelease,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    setNextVersion,
+    commitNextVersion,
+    pushChanges
+  )
 )
 
-lazy val reactiveLib = (project in file("."))
-  .enablePlugins(AutomateHeaderPlugin)
-  .settings(sharedSettings)
-  .settings(name := "reactive-lib")
+lazy val root = (project in file("."))
   .aggregate(
-    common,
     akka24,
     akka25,
+    common,
     lagom13Java,
     lagom13Scala,
     lagom14Java,
     lagom14Scala,
     play25,
     play26
+  )
+  .settings(sharedSettings)
+  .settings(
+    name := "reactive-lib",
+    publishArtifact := false
   )
 
 lazy val common = (project in file("common"))
@@ -48,7 +76,8 @@ lazy val common = (project in file("common"))
     name := "reactive-lib-common",
     libraryDependencies ++= Seq(
       "org.scalatest"     %% "scalatest"  % Versions.scalaTest % "test"
-    )
+    ),
+    crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
   )
 
 lazy val akka24 = (project in file("akka24"))
@@ -57,11 +86,12 @@ lazy val akka24 = (project in file("akka24"))
   .settings(sharedSettings)
   .settings(
     name := "reactive-lib-akka24",
-
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor" % Versions.akka24,
-      "org.scalatest"     %% "scalatest"  % Versions.scalaTest % "test"
-    )
+      "com.typesafe.akka" %% "akka-actor"          % Versions.akka24,
+      "com.lightbend"     %% "service-locator-dns" % Versions.serviceLocatorDns,
+      "org.scalatest"     %% "scalatest"           % Versions.scalaTest % "test"
+    ),
+    crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
   )
 
 lazy val akka25 = (project in file("akka25"))
@@ -70,34 +100,22 @@ lazy val akka25 = (project in file("akka25"))
   .settings(sharedSettings)
   .settings(
     name := "reactive-lib-akka25",
-
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor" % Versions.akka25,
-      "org.scalatest"     %% "scalatest"  % Versions.scalaTest % "test"
-    )
+      "com.typesafe.akka" %% "akka-actor"          % Versions.akka25,
+      "com.lightbend"     %% "service-locator-dns" % Versions.serviceLocatorDns,
+      "org.scalatest"     %% "scalatest"           % Versions.scalaTest % "test"
+    ),
+    crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
   )
 
 lazy val lagom13Java = (project in file("lagom13-java"))
   .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(akka24)
   .settings(sharedSettings)
-  .settings(scala211Settings)
   .settings(
     name := "reactive-lib-lagom13-java",
-
     autoScalaLibrary := false,
-
     crossPaths := false,
-
-    sourceDirectories in Compile ++= Vector(
-      (sourceDirectory in (common, Compile)).value,
-      (sourceDirectory in (akka24, Compile)).value
-    ),
-
-    sourceDirectories in Test ++= Vector(
-      (sourceDirectory in (common, Test)).value,
-      (sourceDirectory in (akka24, Test)).value
-    ),
-
     libraryDependencies ++= Seq(
       "com.lightbend.lagom" %% "lagom-javadsl-client" % Versions.lagom13,
       "org.scalatest"       %% "scalatest"            % Versions.scalaTest % "test"
@@ -106,113 +124,68 @@ lazy val lagom13Java = (project in file("lagom13-java"))
 
 lazy val lagom13Scala = (project in file("lagom13-scala"))
   .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(akka24)
   .settings(sharedSettings)
-  .settings(scala211Settings)
   .settings(
     name := "reactive-lib-lagom13-scala",
-
-    sourceDirectories in Compile ++= Vector(
-      (sourceDirectory in (common, Compile)).value,
-      (sourceDirectory in (akka24, Compile)).value
-    ),
-
-    sourceDirectories in Test ++= Vector(
-      (sourceDirectory in (common, Test)).value,
-      (sourceDirectory in (akka24, Test)).value
-    ),
-
     libraryDependencies ++= Seq(
-      "com.lightbend.lagom" %% "lagom-scaladsl-client" % Versions.lagom13,
-      "org.scalatest"       %% "scalatest"             % Versions.scalaTest % "test"
+      "com.lightbend.lagom" %% "lagom-scaladsl-client"            % Versions.lagom13,
+      "com.lightbend"       %% "lagom13-java-service-locator-dns" % Versions.serviceLocatorDns,
+      "org.scalatest"       %% "scalatest"                        % Versions.scalaTest % "test"
     )
   )
 
 lazy val lagom14Java = (project in file("lagom14-java"))
   .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(akka25)
   .settings(sharedSettings)
-  .settings(scala211Settings /* @FIXME until a new 2.12 milestone is published */)
   .settings(
     name := "reactive-lib-lagom14-java",
-
     autoScalaLibrary := false,
-
     crossPaths := false,
-
-    // @FIXME remove the sourceDirectories settings when a new 2.12 milestone is published
-
-    sourceDirectories in Compile ++= Vector(
-      (sourceDirectory in (common, Compile)).value,
-      (sourceDirectory in (akka25, Compile)).value
-    ),
-
-    sourceDirectories in Test ++= Vector(
-      (sourceDirectory in (common, Test)).value,
-      (sourceDirectory in (akka25, Test)).value
-    ),
-
     libraryDependencies ++= Seq(
-      "com.lightbend.lagom" %% "lagom-javadsl-client" % Versions.lagom14,
-      "org.scalatest"       %% "scalatest"            % Versions.scalaTest % "test"
+      "com.lightbend.lagom" %% "lagom-javadsl-client"             % Versions.lagom14,
+      "com.lightbend"       %% "lagom13-java-service-locator-dns" % Versions.serviceLocatorDns,
+      "org.scalatest"       %% "scalatest"                        % Versions.scalaTest % "test"
     )
   )
 
 lazy val lagom14Scala = (project in file("lagom14-scala"))
   .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(akka25)
   .settings(sharedSettings)
-  .settings(scala211Settings /* @FIXME until 2.12 Milestone is published */)
   .settings(
     name := "reactive-lib-lagom14-scala",
-
-    // @FIXME remove the sourceDirectories settings when a new 2.12 milestone is published
-
-    sourceDirectories in Compile ++= Vector(
-      (sourceDirectory in (common, Compile)).value,
-      (sourceDirectory in (akka25, Compile)).value
-    ),
-
-    sourceDirectories in Test ++= Vector(
-      (sourceDirectory in (common, Test)).value,
-      (sourceDirectory in (akka25, Test)).value
-    ),
-
     libraryDependencies ++= Seq(
-      "com.lightbend.lagom" %% "lagom-scaladsl-client" % Versions.lagom14,
-      "org.scalatest"       %% "scalatest"             % Versions.scalaTest % "test"
+      "com.lightbend.lagom" %% "lagom-scaladsl-client"            % Versions.lagom14,
+      "com.lightbend"       %% "lagom13-java-service-locator-dns" % Versions.serviceLocatorDns,
+      "org.scalatest"       %% "scalatest"                        % Versions.scalaTest % "test"
     )
   )
 
 lazy val play25 = (project in file("play25"))
   .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(akka24)
   .settings(sharedSettings)
-  .settings(scala211Settings)
   .settings(
     name := "reactive-lib-play25",
-
-    sourceDirectories in Compile ++= Vector(
-      (sourceDirectory in (common, Compile)).value,
-      (sourceDirectory in (akka24, Compile)).value
-    ),
-
-    sourceDirectories in Test ++= Vector(
-      (sourceDirectory in (common, Test)).value,
-      (sourceDirectory in (akka24, Test)).value
-    ),
-
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-ws"   % Versions.play25,
-      "org.scalatest"     %% "scalatest" % Versions.scalaTest % "test"
+      "com.typesafe.play" %% "play-ws"             % Versions.play25,
+      "com.lightbend"     %% "service-locator-dns" % Versions.serviceLocatorDns,
+      "org.scalatest"     %% "scalatest"           % Versions.scalaTest % "test"
     )
   )
 
 lazy val play26 = (project in file("play26"))
   .enablePlugins(AutomateHeaderPlugin)
-  .dependsOn(common, akka25)
+  .dependsOn(akka25)
   .settings(sharedSettings)
   .settings(
     name := "reactive-lib-play26",
-
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-ws"   % Versions.play26,
+      "com.typesafe.play" %% "play-ws"             % Versions.play26,
+      "com.lightbend"     %% "service-locator-dns" % Versions.serviceLocatorDns,
       "org.scalatest"     %% "scalatest" % Versions.scalaTest % "test"
-    )
+    ),
+    crossScalaVersions := Vector(scalaVersion.value, Versions.scala211)
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,5 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header"  % "3.0.2")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "3.0.2")
+addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.6")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.1.0")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "2.0")
+


### PR DESCRIPTION
This adds `service-locator-dns` where appropriate and fixes the build to ensure that it properly builds for 2.11 and 2.12.

Scala 2.11 Only: `play25`, `lagom13`, `lagom14` (for now, until a 2.12 is published)
Scala 2.11 and 2.12: `akka24`, `akka25`, `common`, `play26`